### PR TITLE
Bump org.beryx.runtime from 1.11.3 to 1.11.4 (#6369)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ plugins {
     id 'com.github.ben-manes.versions' version '0.30.0'
     id "com.dorongold.task-tree" version '1.5'
     id 'org.openjfx.javafxplugin' version '0.0.9'
-    id 'org.beryx.runtime' version '1.11.3'
+    id 'org.beryx.runtime' version '1.11.4'
 }
 
 javafx {


### PR DESCRIPTION
Bumps org.beryx.runtime from 1.11.3 to 1.11.4.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

Co-authored-by: dependabot-preview[bot] <27856297+dependabot-preview[bot]@users.noreply.github.com>